### PR TITLE
Fix haste mult

### DIFF
--- a/tbc/auras.go
+++ b/tbc/auras.go
@@ -454,7 +454,7 @@ func ActivateBerserking(sim *Simulation, hasteBonus float64) Aura {
 		ID:      MagicIDTrollBerserking,
 		Expires: sim.CurrentTick + dur,
 		OnCast: func(sim *Simulation, c *Cast) {
-			c.CastTime /= hasteBonus // 30% faster.
+			c.CastTime /= hasteBonus
 			if c.CastTime < 1.0 {
 				c.CastTime = 1.0 // can't cast faster than 1/sec even with max haste.
 			}

--- a/tbc/auras.go
+++ b/tbc/auras.go
@@ -431,9 +431,36 @@ func ActivateDrums(sim *Simulation) Aura {
 }
 
 func ActivateBloodlust(sim *Simulation) Aura {
-	sim.Buffs[StatHaste] += 472.8
-	sim.CDs[MagicIDBloodlust] = 40 * TicksPerSecond // assumes that multiple BLs are different shaman.
-	return AuraStatRemoval(sim.CurrentTick, 40, 472.8, StatHaste, MagicIDBloodlust)
+	const dur = 40 * TicksPerSecond
+	sim.CDs[MagicIDBloodlust] = dur // assumes that multiple BLs are different shaman.
+	return Aura{
+		ID:      MagicIDBloodlust,
+		Expires: sim.CurrentTick + dur,
+		OnCast: func(sim *Simulation, c *Cast) {
+			c.CastTime /= 1.3 // 30% faster.
+			if c.CastTime < 1.0 {
+				c.CastTime = 1.0 // can't cast faster than 1/sec even with max haste.
+			}
+			c.TicksUntilCast = int(c.CastTime*float64(TicksPerSecond)) + 1
+		},
+	}
+}
+
+func ActivateBerserking(sim *Simulation, hasteBonus float64) Aura {
+	const dur = 10 * TicksPerSecond
+	const cd = 180 * TicksPerSecond
+	sim.CDs[MagicIDTrollBerserking] = cd
+	return Aura{
+		ID:      MagicIDTrollBerserking,
+		Expires: sim.CurrentTick + dur,
+		OnCast: func(sim *Simulation, c *Cast) {
+			c.CastTime /= hasteBonus // 30% faster.
+			if c.CastTime < 1.0 {
+				c.CastTime = 1.0 // can't cast faster than 1/sec even with max haste.
+			}
+			c.TicksUntilCast = int(c.CastTime*float64(TicksPerSecond)) + 1
+		},
+	}
 }
 
 func ActivateSkycall(sim *Simulation) Aura {

--- a/tbc/sim2.go
+++ b/tbc/sim2.go
@@ -35,15 +35,13 @@ func (sim *Simulation) ActivateRacial() {
 			sim.CDs[MagicIDOrcBloodFury] = 120 * TicksPerSecond
 		}
 	case RaceBonusTroll10, RaceBonusTroll30:
-		hasteBonus := 157.6 // 10% haste
+		hasteBonus := 1.1 // 10% haste
 		const dur = 10
 		if v == RaceBonusTroll30 {
-			hasteBonus = 472.8 // 30% haste
+			hasteBonus = 1.3 // 30% haste
 		}
 		if sim.CDs[MagicIDTrollBerserking] < 1 {
-			sim.Buffs[StatHaste] += hasteBonus
-			sim.addAura(AuraStatRemoval(sim.CurrentTick, dur, hasteBonus, StatHaste, MagicIDTrollBerserking))
-			sim.CDs[MagicIDTrollBerserking] = 180 * TicksPerSecond
+			sim.addAura(ActivateBerserking(sim, hasteBonus))
 		}
 	}
 }

--- a/tbc/spells.go
+++ b/tbc/spells.go
@@ -7,6 +7,7 @@ type Cast struct {
 
 	// Pre-hit Mutatable State
 	TicksUntilCast int
+	CastTime       float64 // time in seconds to cast the spell
 	ManaCost       float64
 
 	Hit        float64 // Direct % bonus... 0.1 == 10%
@@ -43,7 +44,8 @@ func NewCast(sim *Simulation, sp *Spell) *Cast {
 	if castTime < 1.0 {
 		castTime = 1.0 // can't cast faster than 1/sec even with max haste.
 	}
-	cast.TicksUntilCast = int(castTime * float64(TicksPerSecond))
+	cast.CastTime = castTime
+	cast.TicksUntilCast = int(castTime*float64(TicksPerSecond)) + 1 // round up
 
 	if isLB || isCL {
 		cast.ManaCost *= 1 - (0.02 * float64(sim.Options.Talents.Convection))

--- a/tbc/stats.go
+++ b/tbc/stats.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 )
 
-const TicksPerSecond = 30
+const TicksPerSecond = 60
 
 type Stats []float64
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -264,7 +264,7 @@
         <div id="pullout">
             <div class="dtl" style="height:100%;width:100%;padding:10px">
                 <div id="themetoggle" style="height:20px; bottom: 10px; cursor: pointer;" onclick="toggletheme()">
-                    <text>v0.2.5</text>
+                    <text>v0.2.6</text>
                     <img id="themebulb" style="height: 20px; width: 20px" src="../icons/light-bulb.svg"></img>
                 </div>
                 <div style="margin-top:10px">


### PR DESCRIPTION
v0.2.6

Fixed bloodlust and berserking to now provide percent multiplier instead of additive bonus.
Now round cast up to nearest tick (since partial tick would prevent casting until next tick)
Increase ticks per second to match what the client probably actually runs.